### PR TITLE
[BUGFIX] add normalized cache-dir to composer.json and gitlab matrixes as strings

### DIFF
--- a/bin/mediatis-coding-standards-setup
+++ b/bin/mediatis-coding-standards-setup
@@ -25,7 +25,7 @@ $examplePackagePath = 'example-package';
 $supportedPackageVersions = [
     'php' => [
         'packageKeys' => ['php'],
-        'versions' => [8.1, 8.2],
+        'versions' => ['8.1', '8.2'],
     ],
 ];
 

--- a/example-package/composer.json
+++ b/example-package/composer.json
@@ -37,7 +37,8 @@
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true
-        }
+        },
+        "cache-dir": "./cache/composer"
     },
     "scripts": {
         "ci": [


### PR DESCRIPTION
- Gitlab requires the matrixes to be strings or the CI yaml does not validate. I think GitHub does not care.
- The added cache-dir via before_script modifies the composer.json file of the package during CI action, but does not normalize it, which causes the followup "composer normalize" to fail. That's why we add the cache-dir attribute to the example composer.json so that it can be normalized manually.