### PR TITLE
[BUGFIX] create second phpstan.selftest.neon and use for self testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         ],
         "ci:php:lint": "find .*.php *.php src tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
         "ci:php:rector": "./vendor/bin/rector --dry-run",
-        "ci:php:stan": "php -d memory_limit=228M ./vendor/bin/phpstan --no-progress --no-interaction analyse",
+        "ci:php:stan": "php -d memory_limit=228M ./vendor/bin/phpstan --no-progress --no-interaction analyse -c phpstan.selftest.neon",
         "ci:php:static": [
             "@ci:php:rector",
             "@ci:php:cs-fixer",

--- a/phpstan.selftest.neon
+++ b/phpstan.selftest.neon
@@ -1,6 +1,6 @@
 parameters:
   level: 6
   paths:
-    - ../../../src
-    - ../../../tests
+    - src
+    - tests
   reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Because other packages are referencing phpstan.neon, it has paths relative to vendor folder. We can't use this for self testing so we need a second file that has the correct paths.