### PR TITLE
Drop E_DEPRECATED suppression from CI template

### DIFF
--- a/example-package/.gitlab-ci.yml
+++ b/example-package/.gitlab-ci.yml
@@ -26,7 +26,6 @@ code-quality:
         - 'chmod +x /usr/local/bin/composer'
         - 'composer config cache-dir ./cache/composer'
         - 'cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini'
-        - 'awk ''/^error_reporting = E_ALL/{print "error_reporting = E_ALL & ~E_DEPRECATED"; next}1'' /usr/local/etc/php/php.ini > temp.ini && mv temp.ini /usr/local/etc/php/php.ini'
         - 'composer install --no-progress --ignore-platform-req=ext-intl'
     image: 'php:${php_version}'
     stage: code-quality


### PR DESCRIPTION
## Summary

The CI template generated for new packages globally suppresses \`E_DEPRECATED\` in \`php.ini\` before running the matrix. This defeats the purpose of running the matrix against newer PHP versions: deprecation warnings (which become fatal in the next major) are exactly what the matrix should be catching, and suppressing them gives false confidence that the package is forward-compatible.

## Test plan

- [x] Verified locally that the awk line removal does not affect existing successful matrix legs (no behavioural dependency on suppression).
- [ ] Generated template on a clean package via \`mediatis-coding-standards-setup\` and confirmed the generated \`.gitlab-ci.yml\` no longer contains the awk line.